### PR TITLE
fix: fetch everything for publish

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,6 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           cache: "npm"


### PR DESCRIPTION
in order to retrieve latest tag from previous workflow step (release)