### PR TITLE
Feature/generate readmes watch

### DIFF
--- a/custom-elements-manifest.config.ts
+++ b/custom-elements-manifest.config.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env ts-node
 
-import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import { customElementExamplesPlugin } from '@webcomponents-preview/cem-plugin-examples';
+import { customElementGenerateReadmesPlugin } from '@webcomponents-preview/cem-plugin-generate-readmes';
 import { customElementGroupingPlugin } from '@webcomponents-preview/cem-plugin-grouping';
-import { customElementInlineReadmePlugin } from '@webcomponents-preview/cem-plugin-inline-readme';
 
 export default {
   packagejson: true,
@@ -15,16 +14,24 @@ export default {
   outdir: 'dist',
   plugins: [
     customElementExamplesPlugin(),
+    customElementGenerateReadmesPlugin({
+      addInlineReadme: true,
+      transformer: 'cem',
+      transformerOptions: {
+        headingOffset: -1,
+        omitDeclarations: ['exports'],
+        omitSections: ['main-heading', 'super-class', 'static-fields', 'static-methods'],
+        private: 'hidden',
+      },
+      outputPath(path) {
+        if (path === undefined) return '';
+        return resolve(dirname(path), 'README.md');
+      },
+    }),
     customElementGroupingPlugin({
       addGroups(componentPath) {
         const [, , group] = componentPath?.split('/') || [];
         return [group];
-      },
-    }),
-    customElementInlineReadmePlugin({
-      loadReadme(path?: string) {
-        if (path === undefined) return '';
-        return readFileSync(resolve(dirname(path), 'README.md')).toString();
       },
     }),
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,9 @@
         "@types/pretty": "2.0.1",
         "@typescript-eslint/eslint-plugin": "5.53.0",
         "@typescript-eslint/parser": "5.53.0",
-        "@webcomponents-preview/cem-plugin-examples": "0.0.28",
-        "@webcomponents-preview/cem-plugin-grouping": "0.0.28",
-        "@webcomponents-preview/cem-plugin-inline-readme": "0.0.28",
+        "@webcomponents-preview/cem-plugin-examples": "0.0.33",
+        "@webcomponents-preview/cem-plugin-generate-readmes": "0.0.33",
+        "@webcomponents-preview/cem-plugin-grouping": "0.0.33",
         "autoprefixer": "10.4.13",
         "barrelsby": "2.5.1",
         "cross-env": "7.0.3",
@@ -53,8 +53,7 @@
         "ts-jest": "29.0.5",
         "ts-node": "10.9.1",
         "typedoc": "0.23.26",
-        "typescript": "4.9.5",
-        "web-component-analyzer": "2.0.0-next.4"
+        "typescript": "4.9.5"
       },
       "engines": {
         "node": "^18"
@@ -3101,9 +3100,21 @@
       "dev": true
     },
     "node_modules/@webcomponents-preview/cem-plugin-examples": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@webcomponents-preview/cem-plugin-examples/-/cem-plugin-examples-0.0.28.tgz",
-      "integrity": "sha512-5kn7uB4GOv9ox4KTcrKwNMIPijdoD6hPxiqGH8bGhAEq4yuOuDA8yxPW86j2IYQdsj4aSO5Lm/KzAG4YZM/gwg==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@webcomponents-preview/cem-plugin-examples/-/cem-plugin-examples-0.0.33.tgz",
+      "integrity": "sha512-lHzte+iakU9a+uhklIwFNCZ4l+RFl4OBb9+NSCKLQN6SMlGv2YW0JNc4SUe3VyC5eYLsop0RQbR4St4QW8tbcQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18"
+      },
+      "peerDependencies": {
+        "@custom-elements-manifest/analyzer": "^0.6.8"
+      }
+    },
+    "node_modules/@webcomponents-preview/cem-plugin-generate-readmes": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@webcomponents-preview/cem-plugin-generate-readmes/-/cem-plugin-generate-readmes-0.0.33.tgz",
+      "integrity": "sha512-kKdvbSHdnuIHgN5REO1cuEuFFY0sQis4BddvvPtzikCE2c9TIJ7dM/Wpuq4H7E70nsd7UC5aofya8YYouI8OIw==",
       "dev": true,
       "engines": {
         "node": "^18"
@@ -3113,21 +3124,9 @@
       }
     },
     "node_modules/@webcomponents-preview/cem-plugin-grouping": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@webcomponents-preview/cem-plugin-grouping/-/cem-plugin-grouping-0.0.28.tgz",
-      "integrity": "sha512-JJEvunsztl1/C5xhgVep94/Us6qxRhGAUPBWlaG+RWNVkAUhoYvjtZgef32gVLceEnf+9+2xJ5v45uoCJM5j2w==",
-      "dev": true,
-      "engines": {
-        "node": "^18"
-      },
-      "peerDependencies": {
-        "@custom-elements-manifest/analyzer": "^0.6.8"
-      }
-    },
-    "node_modules/@webcomponents-preview/cem-plugin-inline-readme": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@webcomponents-preview/cem-plugin-inline-readme/-/cem-plugin-inline-readme-0.0.28.tgz",
-      "integrity": "sha512-5bmdeJnU/5DcCRdtUdNApg3L3/wiX4kd+8yNbFJJ3PW5T7YlQP0tuRsnZBFG1RJwPLctxT+evtL/ggGP3DNxQw==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@webcomponents-preview/cem-plugin-grouping/-/cem-plugin-grouping-0.0.33.tgz",
+      "integrity": "sha512-XyNeuAxptVy8zHZh2V0vlISlitkjHP8MBs/QBahChmXZ5anFYr+8l6/9C1BzydhhkV7Q9CA7+5jxxDoFBADEZA==",
       "dev": true,
       "engines": {
         "node": "^18"
@@ -4560,15 +4559,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -11437,12 +11427,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -11789,12 +11773,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/setprototypeof": {
@@ -12579,12 +12557,6 @@
         }
       }
     },
-    "node_modules/ts-simple-type": {
-      "version": "2.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
-      "integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
-      "dev": true
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -13022,204 +12994,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-component-analyzer": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
-      "integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
-      "dev": true,
-      "dependencies": {
-        "fast-glob": "^3.2.2",
-        "ts-simple-type": "2.0.0-next.0",
-        "typescript": "~4.4.3",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "wca": "cli.js",
-        "web-component-analyzer": "cli.js"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/web-component-analyzer/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "node_modules/web-component-analyzer/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -13317,12 +13091,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-      "dev": true
     },
     "node_modules/which-typed-array": {
       "version": "1.1.9",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
   "scripts": {
     "lint": "eslint --ext .ts src",
     "clean": "shx rm -rf dist",
-    "generate:barrels": "barrelsby --config .barrelsby.json",
-    "generate:readmes": "wca analyze src --format markdown --outFiles '{dir}/README.md'",
-    "generate": "run-p --print-name generate:*",
+    "generate": "barrelsby --config .barrelsby.json",
     "docs": "cross-env NODE_OPTIONS='--loader ts-node/esm' cem analyze --config custom-elements-manifest.config.ts",
     "test": "jest",
     "test:ci": "jest --ci --passWithNoTests --reporters=default --reporters=jest-junit",
@@ -56,9 +54,9 @@
     "@types/pretty": "2.0.1",
     "@typescript-eslint/eslint-plugin": "5.53.0",
     "@typescript-eslint/parser": "5.53.0",
-    "@webcomponents-preview/cem-plugin-examples": "0.0.28",
-    "@webcomponents-preview/cem-plugin-grouping": "0.0.28",
-    "@webcomponents-preview/cem-plugin-inline-readme": "0.0.28",
+    "@webcomponents-preview/cem-plugin-examples": "0.0.33",
+    "@webcomponents-preview/cem-plugin-generate-readmes": "0.0.33",
+    "@webcomponents-preview/cem-plugin-grouping": "0.0.33",
     "autoprefixer": "10.4.13",
     "barrelsby": "2.5.1",
     "cross-env": "7.0.3",
@@ -81,8 +79,7 @@
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typedoc": "0.23.26",
-    "typescript": "4.9.5",
-    "web-component-analyzer": "2.0.0-next.4"
+    "typescript": "4.9.5"
   },
   "engines": {
     "node": "^18"

--- a/src/components/feature/example/README.md
+++ b/src/components/feature/example/README.md
@@ -1,22 +1,44 @@
-# wcp-example
+# class: `Example`
 
-Shows a code example and a preview of the component.
+## Methods
+
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
+
+## CSS Properties
+
+| Name                               | Default | Description                               |
+| ---------------------------------- | ------- | ----------------------------------------- |
+| `--wcp-example-spacing`            |         | Inner padding of the example              |
+| `--wcp-example-border-radius`      |         | Border radius of the example              |
+| `--wcp-example-border-width`       |         | Border width of the example               |
+| `--wcp-example-dark-border-color`  |         | Border color of the example in dark mode  |
+| `--wcp-example-light-border-color` |         | Border color of the example in light mode |
 
 **Mixins:** ColorSchemable
 
 ## Slots
 
 | Name      | Description              |
-|-----------|--------------------------|
+| --------- | ------------------------ |
 | `code`    | Code example             |
 | `preview` | Rendered example preview |
 
-## CSS Custom Properties
+<hr/>
 
-| Property                           | Description                               |
-|------------------------------------|-------------------------------------------|
-| `--wcp-example-border-radius`      | Border radius of the example              |
-| `--wcp-example-border-width`       | Border width of the example               |
-| `--wcp-example-dark-border-color`  | Border color of the example in dark mode  |
-| `--wcp-example-light-border-color` | Border color of the example in light mode |
-| `--wcp-example-spacing`            | Inner padding of the example              |
+# Variables
+
+| Name           | Description | Type     |
+| -------------- | ----------- | -------- |
+| `EXAMPLE_TABS` |             | `object` |
+
+<hr/>
+
+# Functions
+
+| Name | Description | Parameters | Return |
+| ---- | ----------- | ---------- | ------ |
+|      |             |            |        |
+
+<hr/>

--- a/src/components/feature/navigation-item/README.md
+++ b/src/components/feature/navigation-item/README.md
@@ -1,54 +1,47 @@
-# wcp-navigation-item
+# class: `NavigationItem`
 
-**Mixins:** ColorSchemable
+## Fields
 
-## Examples
+| Name     | Privacy | Type                  | Default | Description | Inherited From |
+| -------- | ------- | --------------------- | ------- | ----------- | -------------- |
+| `active` |         | `boolean`             | `false` |             |                |
+| `href`   |         | `string \| undefined` |         |             |                |
 
-### Non-interactive
+## Methods
 
-This will probably only be used for the active item.
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
 
-```html
-<wcp-navigation-item>
-  Non-interactive
-</wcp-navigation-item>
-```
+## Attributes
 
-### With link
+| Name     | Field  | Inherited From |
+| -------- | ------ | -------------- |
+| `active` | active |                |
+| `href`   | href   |                |
 
-```html
-<wcp-navigation-item href="/home">
-  Home
-</wcp-navigation-item>
-```
+## CSS Properties
 
-## Properties
-
-| Property | Attribute | Type                  | Default |
-|----------|-----------|-----------------------|---------|
-| `active` | `active`  | `boolean`             | false   |
-| `href`   | `href`    | `string \| undefined` |         |
+| Name                                             | Default | Description                                                     |
+| ------------------------------------------------ | ------- | --------------------------------------------------------------- |
+| `--wcp-navigation-item-spacing`                  |         | Inner padding of the item                                       |
+| `--wcp-navigation-item-dark-passive-background`  |         | Background color of the item when non interactive in dark mode  |
+| `--wcp-navigation-item-dark-hover-background`    |         | Background color of the item when hovered in dark mode          |
+| `--wcp-navigation-item-dark-active-background`   |         | Background color of the item when active in dark mode           |
+| `--wcp-navigation-item-dark-passive-color`       |         | Text color of the item when non interactive in dark mode        |
+| `--wcp-navigation-item-dark-hover-color`         |         | Text color of the item when hovered in dark mode                |
+| `--wcp-navigation-item-dark-active-color`        |         | Text color of the item when active in dark mode                 |
+| `--wcp-navigation-item-light-passive-background` |         | Background color of the item when non interactive in light mode |
+| `--wcp-navigation-item-light-hover-background`   |         | Background color of the item when hovered in light mode         |
+| `--wcp-navigation-item-light-active-background`  |         | Background color of the item when active in light mode          |
+| `--wcp-navigation-item-light-passive-color`      |         | Text color of the item when non interactive in light mode       |
+| `--wcp-navigation-item-light-hover-color`        |         | Text color of the item when hovered in light mode               |
+| `--wcp-navigation-item-light-active-color`       |         | Text color of the item when active in light mode                |
 
 ## Slots
 
 | Name | Description               |
-|------|---------------------------|
+| ---- | ------------------------- |
 |      | Default slot for contents |
 
-## CSS Custom Properties
-
-| Property                                         | Description                                      |
-|--------------------------------------------------|--------------------------------------------------|
-| `--wcp-navigation-item-dark-active-background`   | Background color of the item when active in dark mode |
-| `--wcp-navigation-item-dark-active-color`        | Text color of the item when active in dark mode  |
-| `--wcp-navigation-item-dark-hover-background`    | Background color of the item when hovered in dark mode |
-| `--wcp-navigation-item-dark-hover-color`         | Text color of the item when hovered in dark mode |
-| `--wcp-navigation-item-dark-passive-background`  | Background color of the item when non interactive in dark mode |
-| `--wcp-navigation-item-dark-passive-color`       | Text color of the item when non interactive in dark mode |
-| `--wcp-navigation-item-light-active-background`  | Background color of the item when active in light mode |
-| `--wcp-navigation-item-light-active-color`       | Text color of the item when active in light mode |
-| `--wcp-navigation-item-light-hover-background`   | Background color of the item when hovered in light mode |
-| `--wcp-navigation-item-light-hover-color`        | Text color of the item when hovered in light mode |
-| `--wcp-navigation-item-light-passive-background` | Background color of the item when non interactive in light mode |
-| `--wcp-navigation-item-light-passive-color`      | Text color of the item when non interactive in light mode |
-| `--wcp-navigation-item-spacing`                  | Inner padding of the item                        |
+<hr/>

--- a/src/components/feature/navigation/README.md
+++ b/src/components/feature/navigation/README.md
@@ -1,41 +1,42 @@
-# wcp-navigation
+# class: `Navigation`
 
-**Mixins:** ColorSchemable
+## Fields
 
-## Example
+| Name       | Privacy | Type                  | Default | Description | Inherited From |
+| ---------- | ------- | --------------------- | ------- | ----------- | -------------- |
+| `headline` |         | `string \| undefined` |         |             |                |
 
-### Usage with headline
+## Methods
 
-```html
-<wcp-navigation headline="Navigation">
-  <wcp-navigation-item href="/home">Home</wcp-navigation-item>
-  <wcp-navigation-item href="/about">About</wcp-navigation-item>
-</wcp-navigation>
-```
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
 
-## Properties
+## Attributes
 
-| Property   | Attribute  | Type                  |
-|------------|------------|-----------------------|
-| `headline` | `headline` | `string \| undefined` |
+| Name       | Field    | Inherited From |
+| ---------- | -------- | -------------- |
+| `headline` | headline |                |
+
+## CSS Properties
+
+| Name                                         | Default | Description                                               |
+| -------------------------------------------- | ------- | --------------------------------------------------------- |
+| `--wcp-navigation-spacing`                   |         | Spacing between navigation and headline                   |
+| `--wcp-navigation-spacing-items`             |         | Spacing between navigation items                          |
+| `--wcp-navigation-spacing-headline`          |         | Inner padding of the navigation headline                  |
+| `--wcp-navigation-dark-border-color`         |         | Border color of the navigation headline in dark mode      |
+| `--wcp-navigation-light-border-color`        |         | Border color of the navigation headline in light mode     |
+| `--wcp-navigation-headline-size`             |         | Font size of the navigation headline                      |
+| `--wcp-navigation-headline-weight`           |         | Font weight of the navigation headline                    |
+| `--wcp-navigation-headline-spacing`          |         | Letter spacing of the navigation headline                 |
+| `--wcp-navigation-headline-dark-background`  |         | Background color of the navigation headline in dark mode  |
+| `--wcp-navigation-headline-light-background` |         | Background color of the navigation headline in light mode |
 
 ## Slots
 
 | Name | Description                       |
-|------|-----------------------------------|
+| ---- | --------------------------------- |
 |      | Default slot for navigation items |
 
-## CSS Custom Properties
-
-| Property                                     | Description                                      |
-|----------------------------------------------|--------------------------------------------------|
-| `--wcp-navigation-dark-border-color`         | Border color of the navigation headline in dark mode |
-| `--wcp-navigation-headline-dark-background`  | Background color of the navigation headline in dark mode |
-| `--wcp-navigation-headline-light-background` | Background color of the navigation headline in light mode |
-| `--wcp-navigation-headline-size`             | Font size of the navigation headline             |
-| `--wcp-navigation-headline-spacing`          | Letter spacing of the navigation headline        |
-| `--wcp-navigation-headline-weight`           | Font weight of the navigation headline           |
-| `--wcp-navigation-light-border-color`        | Border color of the navigation headline in light mode |
-| `--wcp-navigation-spacing`                   | Spacing between navigation and headline          |
-| `--wcp-navigation-spacing-headline`          | Inner padding of the navigation headline         |
-| `--wcp-navigation-spacing-items`             | Spacing between navigation items                 |
+<hr/>

--- a/src/components/feature/preview-controls/README.md
+++ b/src/components/feature/preview-controls/README.md
@@ -1,34 +1,26 @@
-# wcp-preview-controls
+# class: `PreviewControls`
 
-**Mixins:** ColorSchemable
+## Methods
 
-## Examples
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
 
-```html
-<wcp-preview-controls></wcp-preview-controls>
-```
+## CSS Properties
 
-### Usage with controls
-
-```html
-<wcp-preview-controls>
-  <wcp-preview-controls-viewport></wcp-preview-controls-viewport>
-</wcp-preview-controls>
-```
+| Name                                      | Default | Description                                            |
+| ----------------------------------------- | ------- | ------------------------------------------------------ |
+| `--wcp-preview-controls-dark-background`  |         | Background color of the preview controls in dark mode  |
+| `--wcp-preview-controls-dark-color`       |         | Text color of the preview controls in dark mode        |
+| `--wcp-preview-controls-light-background` |         | Background color of the preview controls in light mode |
+| `--wcp-preview-controls-light-color`      |         | Text color of the preview controls in light mode       |
+| `--wcp-preview-controls-height`           |         | Overall height of the preview controls nav bar         |
+| `--wcp-preview-controls-spacing`          |         | Inner spacing, used as padding of the controls         |
 
 ## Slots
 
 | Name | Description                       |
-|------|-----------------------------------|
+| ---- | --------------------------------- |
 |      | Default slot for navigation items |
 
-## CSS Custom Properties
-
-| Property                                  | Description                                      |
-|-------------------------------------------|--------------------------------------------------|
-| `--wcp-preview-controls-dark-background`  | Background color of the preview controls in dark mode |
-| `--wcp-preview-controls-dark-color`       | Text color of the preview controls in dark mode  |
-| `--wcp-preview-controls-height`           | Overall height of the preview controls nav bar   |
-| `--wcp-preview-controls-light-background` | Background color of the preview controls in light mode |
-| `--wcp-preview-controls-light-color`      | Text color of the preview controls in light mode |
-| `--wcp-preview-controls-spacing`          | Inner spacing, used as padding of the controls   |
+<hr/>

--- a/src/components/feature/preview-details/README.md
+++ b/src/components/feature/preview-details/README.md
@@ -1,1 +1,9 @@
-# wcp-preview-details
+# class: `PreviewDetails`
+
+## Methods
+
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
+
+<hr/>

--- a/src/components/feature/preview-frame/README.md
+++ b/src/components/feature/preview-frame/README.md
@@ -1,31 +1,40 @@
-# wcp-preview-frame
+# class: `PreviewFrame`
 
-**Mixins:** ColorSchemable
+## Fields
 
-## Example
+| Name            | Privacy | Type                                    | Default | Description | Inherited From |
+| --------------- | ------- | --------------------------------------- | ------- | ----------- | -------------- |
+| `preview`       |         | `string`                                | `''`    |             |                |
+| `examples`      |         | `string[]`                              | `[]`    |             |                |
+| `activeElement` |         | `CustomElementDeclaration \| undefined` |         |             |                |
 
-```html
-<wcp-preview-frame></wcp-preview-frame>
-```
+## Methods
 
-## Properties
+| Name             | Privacy   | Description | Parameters                                      | Return           | Inherited From |
+| ---------------- | --------- | ----------- | ----------------------------------------------- | ---------------- | -------------- |
+| `renderExamples` | protected |             | `element: CustomElementDeclarationWithExamples` | `TemplateResult` |                |
+| `renderReadme`   | protected |             | `element: CustomElementDeclarationWithReadme`   | `TemplateResult` |                |
+| `render`         | protected |             |                                                 | `TemplateResult` |                |
 
-| Property        | Attribute       | Type                                    | Default |
-|-----------------|-----------------|-----------------------------------------|---------|
-| `activeElement` | `activeElement` | `CustomElementDeclaration \| undefined` |         |
-| `examples`      |                 | `string[]`                              | []      |
-| `preview`       |                 | `string`                                | ""      |
+## Attributes
 
-## CSS Custom Properties
+| Name            | Field         | Inherited From |
+| --------------- | ------------- | -------------- |
+| `activeElement` | activeElement |                |
 
-| Property                                 | Description                                      |
-|------------------------------------------|--------------------------------------------------|
-| `--wcp-preview-frame-border-width`       | Border width of the example section              |
-| `--wcp-preview-frame-dark-background`    | Background color of the preview frame in dark mode |
-| `--wcp-preview-frame-dark-border-color`  | Border color of the example section in dark mode |
-| `--wcp-preview-frame-dark-color`         | Text color of the preview frame in dark mode     |
-| `--wcp-preview-frame-distance`           | Outer margin of the preview frame                |
-| `--wcp-preview-frame-light-background`   | Background color of the preview frame in light mode |
-| `--wcp-preview-frame-light-border-color` | Border color of the example section in light mode |
-| `--wcp-preview-frame-light-color`        | Text color of the preview frame in light mode    |
-| `--wcp-preview-frame-spacing`            | Inner padding of the preview frame               |
+## CSS Properties
+
+| Name                                     | Default | Description                                         |
+| ---------------------------------------- | ------- | --------------------------------------------------- |
+| `--wcp-preview-frame-dark-background`    |         | Background color of the preview frame in dark mode  |
+| `--wcp-preview-frame-dark-border-color`  |         | Border color of the example section in dark mode    |
+| `--wcp-preview-frame-dark-color`         |         | Text color of the preview frame in dark mode        |
+| `--wcp-preview-frame-light-background`   |         | Background color of the preview frame in light mode |
+| `--wcp-preview-frame-light-border-color` |         | Border color of the example section in light mode   |
+| `--wcp-preview-frame-light-color`        |         | Text color of the preview frame in light mode       |
+| `--wcp-preview-frame-distance`           |         | Outer margin of the preview frame                   |
+| `--wcp-preview-frame-spacing`            |         | Inner padding of the preview frame                  |
+| `--wcp-preview-frame-border-width`       |         | Border width of the example section                 |
+| `--wcp-preview-frame-spacing`            |         | Inner padding of the example section                |
+
+<hr/>

--- a/src/components/feature/readme/README.md
+++ b/src/components/feature/readme/README.md
@@ -1,24 +1,23 @@
-# wcp-readme
+# class: `Readme`
 
-**Mixins:** ColorSchemable
+## Fields
 
-## Example
-
-```html
-<wcp-readme>
- <h1>Readme</h1>
- <p>Some readme content</p>
-</wcp-readme>
-```
-
-## Properties
-
-| Property   | Attribute  | Type     |
-|------------|------------|----------|
-| `markdown` | `markdown` | `string` |
+| Name       | Privacy | Type     | Default | Description | Inherited From |
+| ---------- | ------- | -------- | ------- | ----------- | -------------- |
+| `markdown` |         | `string` |         |             |                |
 
 ## Methods
 
-| Method             | Type       |
-|--------------------|------------|
-| `createRenderRoot` | `(): this` |
+| Name                | Privacy   | Description | Parameters | Return           | Inherited From |
+| ------------------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `createRenderRoot`  |           |             |            |                  |                |
+| `connectedCallback` |           |             |            |                  |                |
+| `render`            | protected |             |            | `TemplateResult` |                |
+
+## Attributes
+
+| Name       | Field    | Inherited From |
+| ---------- | -------- | -------------- |
+| `markdown` | markdown |                |
+
+<hr/>

--- a/src/components/feature/toggle-sidebar/README.md
+++ b/src/components/feature/toggle-sidebar/README.md
@@ -1,21 +1,10 @@
-# wcp-toggle-sidebar
-
-Shows a button to toggle sidebar.
-
-## Example
-
-```html
-<wcp-toggle-sidebar></wcp-toggle-sidebar>
-```
+# class: `ToggleSidebar`
 
 ## Methods
 
-| Method              | Type       |
-|---------------------|------------|
-| `handleButtonClick` | `(): void` |
+| Name                | Privacy   | Description | Parameters | Return           | Inherited From |
+| ------------------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `handleButtonClick` |           |             |            |                  |                |
+| `render`            | protected |             |            | `TemplateResult` |                |
 
-## Events
-
-| Event              |
-|--------------------|
-| `wcp-aside:toggle` |
+<hr/>

--- a/src/components/layout/aside/README.md
+++ b/src/components/layout/aside/README.md
@@ -1,52 +1,52 @@
-# wcp-aside
+# class: `Aside`
 
-To toggle the side bar remotely, you can dispatch a custom event on the global window object:
-```js
-window.dispatchEvent(new CustomEvent('wcp-aside:toggle'));
-```
-You may pass an optional boolean value to the event to toggle the side bar to a specific state:
-```js
-window.dispatchEvent(new CustomEvent('wcp-aside:toggle', { detail: true }));
-```
+## Fields
 
-**Mixins:** ColorSchemable
-
-## Properties
-
-| Property            | Attribute | Type      | Default                                          | Description                                      |
-|---------------------|-----------|-----------|--------------------------------------------------|--------------------------------------------------|
-| `hidden`            | `hidden`  | `boolean` | false                                            | Used to toggle the width of the aside bar        |
-| `listenAsideToggle` |           |           | "(({ detail }: CustomEvent<boolean \| null>) => {\n    this.hidden = detail ?? !this.hidden;\n    this.emitToggled();\n  }).bind(this)" |                                                  |
-| `role`              | `role`    | `string`  | "complementary"                                  | Presets the aria role to `complementary` as we do not use te aside element directly |
+| Name                | Privacy | Type      | Default           | Description                                                                           | Inherited From |
+| ------------------- | ------- | --------- | ----------------- | ------------------------------------------------------------------------------------- | -------------- |
+| `hidden`            |         | `boolean` | `false`           | Used to toggle the width of the aside bar                                             |                |
+| `role`              |         | `string`  | `'complementary'` | Presets the aria role to \`complementary\` as we do not use te aside element directly |                |
+| `listenAsideToggle` |         |           |                   |                                                                                       |                |
 
 ## Methods
 
-| Method              | Type       |
-|---------------------|------------|
-| `emitToggled`       | `(): void` |
-| `handleButtonClick` | `(): void` |
+| Name                   | Privacy   | Description | Parameters | Return           | Inherited From |
+| ---------------------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `emitToggled`          |           |             |            |                  |                |
+| `handleButtonClick`    |           |             |            |                  |                |
+| `connectedCallback`    |           |             |            |                  |                |
+| `disconnectedCallback` |           |             |            |                  |                |
+| `render`               | protected |             |            | `TemplateResult` |                |
 
 ## Events
 
-| Event               | Type                   | Description                                      |
-|---------------------|------------------------|--------------------------------------------------|
-| `wcp-aside-toggled` |                        | Dispatches this event when the side bar has been toggled. Do not get confused with the `wcp-aside:toggle` event. |
-| `wcp-aside:toggled` | `CustomEvent<boolean>` |                                                  |
+| Name                | Type | Description                                                                                                        | Inherited From |
+| ------------------- | ---- | ------------------------------------------------------------------------------------------------------------------ | -------------- |
+| `wcp-aside-toggled` |      | Dispatches this event when the side bar has been toggled. Do not get confused with the \`wcp-aside:toggle\` event. |                |
+
+## Attributes
+
+| Name     | Field  | Inherited From |
+| -------- | ------ | -------------- |
+| `hidden` | hidden |                |
+| `role`   | role   |                |
+
+## CSS Properties
+
+| Name                           | Default | Description                                        |
+| ------------------------------ | ------- | -------------------------------------------------- |
+| `--wcp-aside-max-width`        |         | The maximum width of the aside bar when visible    |
+| `--wcp-aside-spacing`          |         | Inner padding of the aside bar                     |
+| `--wcp-aside-toggle-size`      |         | The size of the toggle button                      |
+| `--wcp-aside-dark-background`  |         | The background color of the side bar in dark mode  |
+| `--wcp-aside-dark-color`       |         | The color of the side bar in dark mode             |
+| `--wcp-aside-light-background` |         | The background color of the side bar in light mode |
+| `--wcp-aside-light-color`      |         | The color of the side bar in light mode            |
 
 ## Slots
 
 | Name | Description                              |
-|------|------------------------------------------|
+| ---- | ---------------------------------------- |
 |      | Projects elements aside the main content |
 
-## CSS Custom Properties
-
-| Property                       | Description                                      |
-|--------------------------------|--------------------------------------------------|
-| `--wcp-aside-dark-background`  | The background color of the side bar in dark mode |
-| `--wcp-aside-dark-color`       | The color of the side bar in dark mode           |
-| `--wcp-aside-light-background` | The background color of the side bar in light mode |
-| `--wcp-aside-light-color`      | The color of the side bar in light mode          |
-| `--wcp-aside-max-width`        | The maximum width of the aside bar when visible  |
-| `--wcp-aside-spacing`          | Inner padding of the aside bar                   |
-| `--wcp-aside-toggle-size`      | The size of the toggle button                    |
+<hr/>

--- a/src/components/layout/layout/README.md
+++ b/src/components/layout/layout/README.md
@@ -1,17 +1,16 @@
-# wcp-layout
+# class: `Layout`
 
-## Example
+## Methods
 
-```html
-<wcp-layout>
-  <nav slot="aside">To the left!</nav>
-  <article>Me the important content!</article>
-</wcp-layout>
-```
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
 
 ## Slots
 
 | Name    | Description                              |
-|---------|------------------------------------------|
-|         | Receives the content of the main section |
+| ------- | ---------------------------------------- |
 | `aside` | Projects elements aside the main content |
+|         | Receives the content of the main section |
+
+<hr/>

--- a/src/components/layout/main/README.md
+++ b/src/components/layout/main/README.md
@@ -1,13 +1,27 @@
-# wcp-main
+# class: `Main`
 
-## Properties
+## Fields
 
-| Property | Attribute | Type     | Default | Description                                      |
-|----------|-----------|----------|---------|--------------------------------------------------|
-| `role`   | `role`    | `string` | "main"  | Presets the aria role to `main` as we do not use te main element directly |
+| Name   | Privacy | Type     | Default  | Description                                                                 | Inherited From |
+| ------ | ------- | -------- | -------- | --------------------------------------------------------------------------- | -------------- |
+| `role` |         | `string` | `'main'` | Presets the aria role to \`main\` as we do not use te main element directly |                |
+
+## Methods
+
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
+
+## Attributes
+
+| Name   | Field | Inherited From |
+| ------ | ----- | -------------- |
+| `role` | role  |                |
 
 ## Slots
 
 | Name | Description                           |
-|------|---------------------------------------|
+| ---- | ------------------------------------- |
 |      | Projects elements to the main content |
+
+<hr/>

--- a/src/components/root/README.md
+++ b/src/components/root/README.md
@@ -1,52 +1,59 @@
-# wcp-root
+# class: `Root`
 
-**Mixins:** ColorSchemable
+## Fields
 
-## Properties
-
-| Property            | Attribute             | Type                                         | Default                                          | Description                                      |
-|---------------------|-----------------------|----------------------------------------------|--------------------------------------------------|--------------------------------------------------|
-| `activeElement`     | `active-element`      | `string \| undefined`                        |                                                  | Sets the currently active element by its tag name. Will be updated at runtime and can<br />be preset with an initial value to define the active element at startup. |
-| `configUrl`         | `config-url`          | `string \| undefined`                        |                                                  | Allows to set a url to load a config file from.  |
-| `elements`          |                       | `CustomElementDeclaration[]`                 | []                                               |                                                  |
-| `fallbackGroupName` | `fallback-group-name` | `string`                                     | "Components"                                     | Allows to set a fallback group name for elements that do not have a `groups` property.<br />So this is the name of the group that will contain all elements unless the manifest is<br />generated with the optional `@webcomponents-preview/cem-plugin-grouping` plugin. |
-| `handleHashChange`  |                       |                                              | "(() => {\n    const [, activeElement] = window.location.hash.split('#/');\n    this.activeElement = activeElement;\n    this.emitActiveElementChanged();\n  }).bind(this)" |                                                  |
-| `inline`            | `inline`              | `boolean`                                    | false                                            | Flags the component to be displayed inline and not standalone. Requires the surrounding<br />layout to provide the necessary styles like for any other block element. |
-| `manifestUrl`       | `manifest-url`        | `string \| undefined`                        |                                                  | Defines the location of the custom element manifest file. |
-| `navigation`        |                       | `Record<string, CustomElementDeclaration[]>` | {}                                               |                                                  |
-| `title`             | `title`               | `string`                                     |                                                  |                                                  |
+| Name                | Privacy | Type                                         | Default        | Description                                                                                                                                                                                                                                                                | Inherited From |
+| ------------------- | ------- | -------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `elements`          |         | `CustomElementDeclaration[]`                 | `[]`           |                                                                                                                                                                                                                                                                            |                |
+| `navigation`        |         | `Record<string, CustomElementDeclaration[]>` | `{}`           |                                                                                                                                                                                                                                                                            |                |
+| `title`             |         | `string`                                     |                |                                                                                                                                                                                                                                                                            |                |
+| `inline`            |         | `boolean`                                    | `false`        | Flags the component to be displayed inline and not standalone. Requires the surrounding&#xA;layout to provide the necessary styles like for any other block element.                                                                                                       |                |
+| `fallbackGroupName` |         | `string`                                     | `'Components'` | Allows to set a fallback group name for elements that do not have a \`groups\` property.&#xA;So this is the name of the group that will contain all elements unless the manifest is&#xA;generated with the optional \`@webcomponents-preview/cem-plugin-grouping\` plugin. |                |
+| `activeElement`     |         | `string \| undefined`                        |                | Sets the currently active element by its tag name. Will be updated at runtime and can&#xA;be preset with an initial value to define the active element at startup.                                                                                                         |                |
+| `configUrl`         |         | `string \| undefined`                        |                | Allows to set a url to load a config file from.                                                                                                                                                                                                                            |                |
+| `manifestUrl`       |         | `string \| undefined`                        |                | Defines the location of the custom element manifest file.                                                                                                                                                                                                                  |                |
+| `handleHashChange`  |         |                                              |                |                                                                                                                                                                                                                                                                            |                |
 
 ## Methods
 
-| Method                        | Type                                        |
-|-------------------------------|---------------------------------------------|
-| `emitActiveElementChanged`    | `(): void`                                  |
-| `emitManifestLoaded`          | `(): void`                                  |
-| `getActiveElementDeclaration` | `(): CustomElementDeclaration \| undefined` |
-| `loadCustomElementsManifest`  | `(): Promise<void>`                         |
-| `selectFallbackElement`       | `(): Promise<void>`                         |
+| Name                          | Privacy   | Description | Parameters | Return                                  | Inherited From |
+| ----------------------------- | --------- | ----------- | ---------- | --------------------------------------- | -------------- |
+| `loadCustomElementsManifest`  |           |             |            |                                         |                |
+| `selectFallbackElement`       |           |             |            |                                         |                |
+| `getActiveElementDeclaration` |           |             |            | `CustomElementDeclaration \| undefined` |                |
+| `emitManifestLoaded`          |           |             |            |                                         |                |
+| `emitActiveElementChanged`    |           |             |            |                                         |                |
+| `connectedCallback`           |           |             |            |                                         |                |
+| `disconnectedCallback`        |           |             |            |                                         |                |
+| `render`                      | protected |             |            | `TemplateResult`                        |                |
 
-## Events
+## Attributes
 
-| Event                             | Type                                      | Description                                      |
-|-----------------------------------|-------------------------------------------|--------------------------------------------------|
-| `wcp-root:active-element-changed` | `CustomEvent<CustomElementDeclaration>`   | Fired when the active element changes. Carries the declaration of the new active element with it. |
-| `wcp-root:manifest-loaded`        | `CustomEvent<CustomElementDeclaration[]>` | Fired when the manifest is (re)loaded. This happens after the json is fetched and the containing elements are resolved. |
+| Name                  | Field             | Inherited From |
+| --------------------- | ----------------- | -------------- |
+| `title`               | title             |                |
+| `inline`              | inline            |                |
+| `fallback-group-name` | fallbackGroupName |                |
+| `active-element`      | activeElement     |                |
+| `config-url`          | configUrl         |                |
+| `manifest-url`        | manifestUrl       |                |
+
+## CSS Properties
+
+| Name                          | Default | Description                                                  |
+| ----------------------------- | ------- | ------------------------------------------------------------ |
+| `--wcp-root-dark-background`  |         | The background color of the root element in dark mode        |
+| `--wcp-root-dark-color`       |         | The text color of the text in the root element in dark mode  |
+| `--wcp-root-light-background` |         | The background color of the root element in light mode       |
+| `--wcp-root-light-color`      |         | The text color of the text in the root element in light mode |
 
 ## Slots
 
-| Name               | Description                                      |
-|--------------------|--------------------------------------------------|
+| Name               | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
 | `logo`             | Allows setting a custom logo to be displayed in the title. |
-| `preview-controls` | Can be used to inject additional preview controls. |
-| `preview-details`  | Can be used to inject additional preview detail panes. |
-| `preview-frame`    | Used to be override the existing preview pane.   |
+| `preview-controls` | Can be used to inject additional preview controls.         |
+| `preview-frame`    | Used to be override the existing preview pane.             |
+| `preview-details`  | Can be used to inject additional preview detail panes.     |
 
-## CSS Custom Properties
-
-| Property                      | Description                                      |
-|-------------------------------|--------------------------------------------------|
-| `--wcp-root-dark-background`  | The background color of the root element in dark mode |
-| `--wcp-root-dark-color`       | The text color of the text in the root element in dark mode |
-| `--wcp-root-light-background` | The background color of the root element in light mode |
-| `--wcp-root-light-color`      | The text color of the text in the root element in light mode |
+<hr/>

--- a/src/components/ui/button/README.md
+++ b/src/components/ui/button/README.md
@@ -1,78 +1,57 @@
-# wcp-button
+# class: `Button`
 
-Shows a button element.
+## Fields
 
-**Mixins:** ColorSchemable
-
-## Examples
-
-## Default button
-
-```html
-<wcp-button>Click me!</wcp-button>
-```
-
-## Button with icon
-
-```html
-<wcp-button kind="icon">
- <wcp-icon name="menu"></wcp-icon>
-</wcp-button>
-```
-
-## Use as native submit button in form
-
-```html
-<form onsubmit="alert('Submit!'); return false">
- <wcp-button type="submit">Submit</wcp-button>
-</form>
-```
-
-## Use as native reset button in form
-
-```html
-<form onreset="alert('Reset!'); return false">
-  <wcp-button type="reset">Reset</wcp-button>
-</form>
-```
-
-## Properties
-
-| Property    | Attribute   | Type                                             | Default  |
-|-------------|-------------|--------------------------------------------------|----------|
-| `disabled`  | `disabled`  | `boolean`                                        | false    |
-| `href`      | `href`      | `string \| undefined`                            |          |
-| `kind`      | `kind`      | `"button" \| "icon"`                             | "button" |
-| `nowrap`    | `nowrap`    | `boolean`                                        | false    |
-| `stretched` | `stretched` | `boolean`                                        | false    |
-| `target`    | `target`    | `"_self" \| "_blank" \| "_parent" \| "_top" \| undefined` |          |
-| `type`      | `type`      | `"button" \| "reset" \| "submit"`                | "button" |
+| Name        | Privacy | Type                                                      | Default    | Description | Inherited From |
+| ----------- | ------- | --------------------------------------------------------- | ---------- | ----------- | -------------- |
+| `disabled`  |         | `boolean`                                                 | `false`    |             |                |
+| `nowrap`    |         | `boolean`                                                 | `false`    |             |                |
+| `stretched` |         | `boolean`                                                 | `false`    |             |                |
+| `kind`      |         | `'button' \| 'icon'`                                      | `'button'` |             |                |
+| `type`      |         | `'button' \| 'reset' \| 'submit'`                         | `'button'` |             |                |
+| `href`      |         | `string \| undefined`                                     |            |             |                |
+| `target`    |         | `'_self' \| '_blank' \| '_parent' \| '_top' \| undefined` |            |             |                |
 
 ## Methods
 
-| Method              | Type       |
-|---------------------|------------|
-| `handleButtonClick` | `(): void` |
+| Name                | Privacy   | Description | Parameters | Return           | Inherited From |
+| ------------------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `handleButtonClick` |           |             |            |                  |                |
+| `render`            | protected |             |            | `TemplateResult` |                |
 
-## CSS Custom Properties
+## Attributes
 
-| Property                                  | Description                                      |
-|-------------------------------------------|--------------------------------------------------|
-| `--wcp-button-dark-active-background`     | Background color of the button if active in dark mode |
-| `--wcp-button-dark-active-border-color`   | Border color of the button if active in dark mode |
-| `--wcp-button-dark-active-color`          | Text color of the button if active in dark mode  |
-| `--wcp-button-dark-hover-background`      | Background color of the button if hovered in dark mode |
-| `--wcp-button-dark-hover-border-color`    | Border color of the button if hovered in dark mode |
-| `--wcp-button-dark-hover-color`           | Text color of the button if hovered in dark mode |
-| `--wcp-button-dark-passive-background`    | Background color of the button if non interactive in dark mode |
-| `--wcp-button-dark-passive-border-color`  | Border color of the button if non interactive in dark mode |
-| `--wcp-button-dark-passive-color`         | Text color of the button if non interactive in dark mode |
-| `--wcp-button-light-active-background`    | Background color of the button if active in light mode |
-| `--wcp-button-light-active-border-color`  | Border color of the button if active in light mode |
-| `--wcp-button-light-active-color`         | Text color of the button if active in light mode |
-| `--wcp-button-light-hover-background`     | Background color of the button if hovered in light mode |
-| `--wcp-button-light-hover-border-color`   | Border color of the button if hovered in light mode |
-| `--wcp-button-light-hover-color`          | Text color of the button if hovered in light mode |
-| `--wcp-button-light-passive-background`   | Background color of the button if non interactive in light mode |
-| `--wcp-button-light-passive-border-color` | Border color of the button if non interactive in light mode |
-| `--wcp-button-light-passive-color`        | Text color of the button if non interactive in light mode |
+| Name        | Field     | Inherited From |
+| ----------- | --------- | -------------- |
+| `disabled`  | disabled  |                |
+| `nowrap`    | nowrap    |                |
+| `stretched` | stretched |                |
+| `kind`      | kind      |                |
+| `type`      | type      |                |
+| `href`      | href      |                |
+| `target`    | target    |                |
+
+## CSS Properties
+
+| Name                                      | Default | Description                                                     |
+| ----------------------------------------- | ------- | --------------------------------------------------------------- |
+| `--wcp-button-dark-passive-background`    |         | Background color of the button if non interactive in dark mode  |
+| `--wcp-button-dark-passive-border-color`  |         | Border color of the button if non interactive in dark mode      |
+| `--wcp-button-dark-passive-color`         |         | Text color of the button if non interactive in dark mode        |
+| `--wcp-button-dark-hover-background`      |         | Background color of the button if hovered in dark mode          |
+| `--wcp-button-dark-hover-border-color`    |         | Border color of the button if hovered in dark mode              |
+| `--wcp-button-dark-hover-color`           |         | Text color of the button if hovered in dark mode                |
+| `--wcp-button-dark-active-background`     |         | Background color of the button if active in dark mode           |
+| `--wcp-button-dark-active-border-color`   |         | Border color of the button if active in dark mode               |
+| `--wcp-button-dark-active-color`          |         | Text color of the button if active in dark mode                 |
+| `--wcp-button-light-passive-background`   |         | Background color of the button if non interactive in light mode |
+| `--wcp-button-light-passive-border-color` |         | Border color of the button if non interactive in light mode     |
+| `--wcp-button-light-passive-color`        |         | Text color of the button if non interactive in light mode       |
+| `--wcp-button-light-hover-background`     |         | Background color of the button if hovered in light mode         |
+| `--wcp-button-light-hover-border-color`   |         | Border color of the button if hovered in light mode             |
+| `--wcp-button-light-hover-color`          |         | Text color of the button if hovered in light mode               |
+| `--wcp-button-light-active-background`    |         | Background color of the button if active in light mode          |
+| `--wcp-button-light-active-border-color`  |         | Border color of the button if active in light mode              |
+| `--wcp-button-light-active-color`         |         | Text color of the button if active in light mode                |
+
+<hr/>

--- a/src/components/ui/icon/README.md
+++ b/src/components/ui/icon/README.md
@@ -1,30 +1,27 @@
-# wcp-icon
+# class: `Icon`
 
-Shows an icon from the css.gg icon set.
+## Fields
 
-## Examples
+| Name   | Privacy | Type     | Default | Description | Inherited From |
+| ------ | ------- | -------- | ------- | ----------- | -------------- |
+| `name` |         | `string` |         |             |                |
 
-## Use icon
-By setting the name attribute.
+## Methods
 
-```html
-<wcp-icon name="smartphone"></wcp-icon>
-```
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
 
-### Set a custom size
+## Attributes
 
-```html
-<wcp-icon name="laptop" style="--wcp-icon-size: 44"></wcp-icon>
-```
+| Name   | Field | Inherited From |
+| ------ | ----- | -------------- |
+| `name` | name  |                |
 
-## Properties
+## CSS Properties
 
-| Property | Attribute | Type     |
-|----------|-----------|----------|
-| `name`   | `name`    | `string` |
+| Name               | Default | Description                                                                                                                                                                                                                                                                                                             |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--wcp-icon-scale` |         | Sets the scale of the icon, where 1 is the default scale at a size of 22px. It is not recommended to set this value yet, until a proper icon set is used and the icon sizes can be set explicitly. The approach of the currently used icons is to (CSS) transform by a given scale, which breaks the layout boundaries. |
 
-## CSS Custom Properties
-
-| Property          | Description                                      |
-|-------------------|--------------------------------------------------|
-| `--wcp-icon-size` | Sets the size of the icon as unitless number in pixels |
+<hr/>

--- a/src/components/ui/tabs/README.md
+++ b/src/components/ui/tabs/README.md
@@ -1,65 +1,49 @@
-# wcp-tabs
+# class: `Tabs`
 
-**Mixins:** ColorSchemable
+## Fields
 
-## Examples
-
-```html
-<wcp-tabs tabs='{"first": "First tab", "second": "Second tab"}'>
- <div slot="first">First tab content</div>
- <div slot="second">Second tab content</div>
-</wcp-tabs>
-```
-
-### Active tab preselected
-
-```html
-<wcp-tabs tabs='{"first": "First tab", "second": "Second tab"}' active-tab="second">
- <div slot="first">First tab content</div>
- <div slot="second">Second tab content</div>
-</wcp-tabs>
-```
-
-## Properties
-
-| Property    | Attribute    | Type                     | Default |
-|-------------|--------------|--------------------------|---------|
-| `activeTab` | `active-tab` | `string \| undefined`    |         |
-| `code`      |              | `string`                 | ""      |
-| `tabFocus`  |              | `number`                 | 0       |
-| `tabRoles`  |              | `HTMLElement[]`          |         |
-| `tabs`      | `tabs`       | `Record<string, string>` | {}      |
+| Name        | Privacy | Type                     | Default | Description | Inherited From |
+| ----------- | ------- | ------------------------ | ------- | ----------- | -------------- |
+| `tabFocus`  |         | `number`                 | `0`     |             |                |
+| `tabRoles`  |         | `HTMLElement[]`          |         |             |                |
+| `code`      |         | `string`                 | `''`    |             |                |
+| `tabs`      |         | `Record<string, string>` | `{}`    |             |                |
+| `activeTab` |         | `string \| undefined`    |         |             |                |
 
 ## Methods
 
-| Method                | Type                           |
-|-----------------------|--------------------------------|
-| `emitActiveTabChange` | `(): void`                     |
-| `handleKeydown`       | `(event: KeyboardEvent): void` |
-| `handleTabClick`      | `(event: Event): void`         |
+| Name                  | Privacy   | Description | Parameters             | Return           | Inherited From |
+| --------------------- | --------- | ----------- | ---------------------- | ---------------- | -------------- |
+| `emitActiveTabChange` |           |             |                        |                  |                |
+| `handleTabClick`      |           |             | `event: Event`         |                  |                |
+| `handleKeydown`       |           |             | `event: KeyboardEvent` |                  |                |
+| `render`              | protected |             |                        | `TemplateResult` |                |
 
-## Events
+## Attributes
 
-| Event                         | Type                                             | Description                          |
-|-------------------------------|--------------------------------------------------|--------------------------------------|
-| `wcp-tabs:active-tab-changed` | `CustomEvent<{ activeTab: string \| undefined; }>` | Notifies when the active tab changes |
+| Name         | Field     | Inherited From |
+| ------------ | --------- | -------------- |
+| `tabs`       | tabs      |                |
+| `active-tab` | activeTab |                |
+
+## CSS Properties
+
+| Name                                       | Default | Description                                      |
+| ------------------------------------------ | ------- | ------------------------------------------------ |
+| `--wcp-tabs-tablist-gap`                   |         | The gap between the tablist and the tabpanels    |
+| `--wcp-tabs-tablist-spacing`               |         | The inner padding of the tablist                 |
+| `--wcp-tabs-tab-spacing`                   |         | The inner padding of the tabs                    |
+| `--wcp-tabs-tab-active-border-width`       |         | The border width of the active tab               |
+| `--wcp-tabs-panel-spacing`                 |         | The inner padding of the tabpanels               |
+| `--wcp-tabs-tablist-dark-border-color`     |         | The border color of the tablist in dark mode     |
+| `--wcp-tabs-tab-active-dark-border-color`  |         | The border color of the active tab in dark mode  |
+| `--wcp-tabs-tablist-light-border-color`    |         | The border color of the tablist in light mode    |
+| `--wcp-tabs-tab-active-light-border-color` |         | The border color of the active tab in light mode |
 
 ## Slots
 
-| Name | Description                              |
-|------|------------------------------------------|
-|      | tab name - The content of the named tab. |
+| Name  | Description                          |
+| ----- | ------------------------------------ |
+| `tab` | name - The content of the named tab. |
 
-## CSS Custom Properties
-
-| Property                                   | Description                                      |
-|--------------------------------------------|--------------------------------------------------|
-| `--wcp-tabs-panel-spacing`                 | The inner padding of the tabpanels               |
-| `--wcp-tabs-tab-active-border-width`       | The border width of the active tab               |
-| `--wcp-tabs-tab-active-dark-border-color`  | The border color of the active tab in dark mode  |
-| `--wcp-tabs-tab-active-light-border-color` | The border color of the active tab in light mode |
-| `--wcp-tabs-tab-spacing`                   | The inner padding of the tabs                    |
-| `--wcp-tabs-tablist-dark-border-color`     | The border color of the tablist in dark mode     |
-| `--wcp-tabs-tablist-gap`                   | The gap between the tablist and the tabpanels    |
-| `--wcp-tabs-tablist-light-border-color`    | The border color of the tablist in light mode    |
-| `--wcp-tabs-tablist-spacing`               | The inner padding of the tablist                 |
+<hr/>

--- a/src/components/ui/title/README.md
+++ b/src/components/ui/title/README.md
@@ -1,36 +1,40 @@
-# wcp-title
+# class: `Title`
 
-Shows the application title and a logo.
+## Fields
 
-## Example
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `title` |         | `string` |         |             |                |
 
-```html
-<wcp-title title="Web Components Preview">
-  <img slot="logo" src="assets/icons/logo.svg" height="30px" />
-</wcp-title>
-```
+## Methods
 
-## Properties
+| Name     | Privacy   | Description | Parameters | Return           | Inherited From |
+| -------- | --------- | ----------- | ---------- | ---------------- | -------------- |
+| `render` | protected |             |            | `TemplateResult` |                |
 
-| Property | Attribute | Type     |
-|----------|-----------|----------|
-| `title`  | `title`   | `string` |
+## Attributes
+
+| Name    | Field | Inherited From |
+| ------- | ----- | -------------- |
+| `title` | title |                |
+
+## CSS Properties
+
+| Name                               | Default | Description                                                     |
+| ---------------------------------- | ------- | --------------------------------------------------------------- |
+| `--wcp-title-gap`                  |         | The gap between the logo and the title                          |
+| `--wcp-title-height`               |         | The height of the title. Content may exceed and scales the tile |
+| `--wcp-title-spacing`              |         | Inner padding of the title                                      |
+| `--wcp-title-headline-size`        |         | The font size of the title                                      |
+| `--wcp-title-headline-weight`      |         | The font weight of the title                                    |
+| `--wcp-title-headline-spacing`     |         | The letter spacing of the title                                 |
+| `--wcp-title-headline-line-height` |         | The line height of the title                                    |
+| `--wcp-title-headline-transform`   |         | The text transform of the title                                 |
 
 ## Slots
 
 | Name   | Description                         |
-|--------|-------------------------------------|
+| ------ | ----------------------------------- |
 | `logo` | Receives the logo image to be shown |
 
-## CSS Custom Properties
-
-| Property                           | Description                                      |
-|------------------------------------|--------------------------------------------------|
-| `--wcp-title-gap`                  | The gap between the logo and the title           |
-| `--wcp-title-headline-line-height` | The line height of the title                     |
-| `--wcp-title-headline-size`        | The font size of the title                       |
-| `--wcp-title-headline-spacing`     | The letter spacing of the title                  |
-| `--wcp-title-headline-transform`   | The text transform of the title                  |
-| `--wcp-title-headline-weight`      | The font weight of the title                     |
-| `--wcp-title-height`               | The height of the title. Content may exceed and scales the tile |
-| `--wcp-title-spacing`              | Inner padding of the title                       |
+<hr/>


### PR DESCRIPTION
Using the new cem plugin allows us to generate the component readmes in its watch mode along with the custom element manifest. So we can remove the web-component-analyzer entirely.

Honestly, the [output of `cem`](https://github.com/webcomponents-preview/client/blob/38bf8c3928fd0f2f310bc7a737f2c96245960ed2/src/components/feature/navigation-item/README.md) isn't as good [compared to `wca`](https://github.com/webcomponents-preview/client/blob/main/src/components/feature/navigation-item/README.md).

So in the near future one will do the right thing, and add a custom manifest to markdown formatter to [`cem-plugin-generate-readmes`](https://github.com/webcomponents-preview/cem-plugins/tree/main/src/cem-plugin-generate-readmes). But for the time being, we'll stick to the actively maintained `cem` analyzer.